### PR TITLE
Rename sort_controls method. Fixes #2

### DIFF
--- a/lib/inspec-reporter-pophtml/reporter.rb
+++ b/lib/inspec-reporter-pophtml/reporter.rb
@@ -52,7 +52,7 @@ module InspecPlugins::PopHtmlReporter
 
       calculate_controls_sums(report_extras)
       calculate_statuses(report_extras)
-      sort_controls(report_extras)
+      sort_controls_by_status(report_extras)
       sort_control_results(report_extras)
 
       report_json_data = report_extras.to_json
@@ -203,7 +203,7 @@ module InspecPlugins::PopHtmlReporter
       end
     end
 
-    def sort_controls(report_extras)
+    def sort_controls_by_status(report_extras)
       run_data['profiles'].each do |profile|
         next unless run_data['controls'].is_a?(Array)
         profile['controls'].sort_by! do |control|

--- a/lib/inspec-reporter-pophtml/version.rb
+++ b/lib/inspec-reporter-pophtml/version.rb
@@ -3,6 +3,6 @@
 # to learn the current version.
 module InspecPlugins
   module PopHtmlReporter
-    VERSION = "0.7.0".freeze
+    VERSION = "0.7.1".freeze
   end
 end


### PR DESCRIPTION
Renamed `sort_controls` method as it was clashing with `sort_controls` from core InSpec. Fixes https://github.com/alexpop/inspec-reporter-pophtml/issues/2